### PR TITLE
Fix html task on serve reapply

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -11,11 +11,11 @@ function serve() {
 
   server.start()
 
-  gulp.watch('app/index.html', (file) => {
-    html()
+  gulp.task('applyHtml', (file) => {
     server.notify.apply(server, [file])
   })
 
+  gulp.watch(['app/index.html'], ['html', 'applyHtml'])
   gulp.watch(['app/**/*.js'], ['scripts'])
   gulp.watch(['app/**/*.css'], ['styles'])
 }


### PR DESCRIPTION
I broke the serve functions ability to reapply the html file when I separated `html` to it's own task file.
