### PR TITLE
Change markup to match docs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -36,7 +36,7 @@
           <textarea name='bio' rows='4'></textarea>
         </div>
 
-        <div class='input-group skills'>
+        <div class='input-group skill'>
           <input name='skills_attributes' type='text' placeholder='Skill'>
           <div class='add-skill'>
             <div class='icon-plus'></div>


### PR DESCRIPTION
The documentation refers to the class `.skill` and depends on it being conceptually an individual skill. Which cause the documentation code to not work with the existing `.skills` markup. This aligns the markup to the [documentation here](http://sandiegojs.org/vanilla-browser-docs/manipulate/#adding-a-skill).
